### PR TITLE
Added typescript support, simplified ruleset

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+* Added typescript support
+* Simplified rules to only use react:recommended, eslint:recommended, react-hooks and some rules from @typescript-eslint/recommended
+
 ## 0.1.0 - 2018-08-31
 * eslint dependencies version upgrade
 

--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ module.exports = {
     'indent': 'off',
     'no-console': 'warn',
 
+    'react/prop-types': 'off',
+
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
 
@@ -40,7 +42,11 @@ module.exports = {
     '@typescript-eslint/no-angle-bracket-type-assertion': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/no-non-null-assertion': 'warn',
-    '@typescript-eslint/prefer-interface': 'warn'
+    '@typescript-eslint/prefer-interface': 'warn',
+    '@typescript-eslint/no-empty-interface': 'off',
+    '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { 'ignoreRestSiblings': true }],
+    '@typescript-eslint/no-object-literal-type-assertion': 'off'
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -5,37 +5,42 @@
  */
 
 module.exports = {
-  extends: 'airbnb',
+  parser: '@typescript-eslint/parser',
   env: {
+    es6: true,
     browser: true,
     node: true,
-    jest: true,
+    jest: true
   },
-  plugins: ['react', 'import', 'babel'],
+  parserOptions: {
+    jsx: true,
+    useJSXTextNode: true
+  },
   settings: {
-    'import/parser': 'babel-eslint',
+    react: {
+      version: 'detect'
+    }
   },
-  parser: 'babel-eslint',
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended'
+  ],
+  plugins: ['@typescript-eslint', 'react-hooks'],
   rules: {
-    'require-jsdoc': ['error', {
-      require: {
-        FunctionDeclaration: true,
-        MethodDefinition: false,
-        ClassDeclaration: true,
-        ArrowFunctionExpression: true,
-        FunctionExpression: true,
-      },
-    }],
-    'no-underscore-dangle': 0,
-    'import/no-extraneous-dependencies': 0,
-    'class-methods-use-this': 0,
-    'arrow-body-style': 0,
-    'import/extensions': ['error', 'ignorePackages', {
-      js: 'never',
-      mjs: 'never',
-      jsx: 'never',
-    }],
-    'react/jsx-one-expression-per-line': 0,
-    'object-curly-newline': 0,
-  },
-};
+    'indent': 'off',
+    'no-console': 'warn',
+
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
+
+    '@typescript-eslint/indent': ['error', 2],
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/camelcase': 'off',
+    '@typescript-eslint/no-angle-bracket-type-assertion': 'off',
+    '@typescript-eslint/explicit-member-accessibility': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'warn',
+    '@typescript-eslint/prefer-interface': 'warn'
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -24,12 +24,10 @@
   },
   "homepage": "https://github.com/environment-agency-austria/eslint-eaa-contrib#readme",
   "peerDependencies": {
-    "babel-eslint": "^9.0.0",
-    "eslint": "^5.4.0",
-    "eslint-config-airbnb": "^17.0.0",
-    "eslint-plugin-babel": "^5.1.0",
-    "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-jsx-a11y": "^6.1.1",
-    "eslint-plugin-react": "^7.11.1"
+    "@typescript-eslint/eslint-plugin": "^1.4.2",
+    "@typescript-eslint/parser": "^1.4.2",
+    "eslint": "^5.14.1",
+    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-react-hooks": "^1.3.0"
   }
 }


### PR DESCRIPTION
* Added typescript support
* Simplified rules to only use [react:recommended](https://github.com/yannickcr/eslint-plugin-react#recommended), [eslint:recommended](https://eslint.org/docs/rules/), [react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) and some rules from [@typescript-eslint/recommended](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#supported-rules)