### PR TITLE
Feature/implicit function return types

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 1.1.0 - 2019-04-10
+* Enabled `allowExpressions` and `allowTypedFunctionExpressions` in `explicit-function-return-type` rule, see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+* Updated peer dependencies
+
 ## 1.0.0 - 2019-03-28
 * Added typescript support
 * Simplified rules to only use react:recommended, eslint:recommended, react-hooks and some rules from @typescript-eslint/recommended

--- a/index.js
+++ b/index.js
@@ -46,7 +46,8 @@ module.exports = {
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/no-unused-vars': ['warn', { 'ignoreRestSiblings': true }],
-    '@typescript-eslint/no-object-literal-type-assertion': 'off'
+    '@typescript-eslint/no-object-literal-type-assertion': 'off',
+    '@typescript-eslint/explicit-function-return-type': ['warn', { 'allowExpressions': true, 'allowTypedFunctionExpressions': true }],
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "homepage": "https://github.com/environment-agency-austria/eslint-eaa-contrib#readme",
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^1.4.2",
-    "@typescript-eslint/parser": "^1.4.2",
-    "eslint": "^5.14.1",
+    "@typescript-eslint/eslint-plugin": "^1.6.0",
+    "@typescript-eslint/parser": "^1.6.0",
+    "eslint": "^5.16.0",
     "eslint-plugin-react": "^7.12.4",
-    "eslint-plugin-react-hooks": "^1.3.0"
+    "eslint-plugin-react-hooks": "^1.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-oceanjs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ESLint rules for EAA projects",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
This PR enables the `allowExpressions` and `allowTypedFunctionExpressions` settings in `explicit-function-return-type` rule, see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md